### PR TITLE
Allow user to specify which tests to care about

### DIFF
--- a/ci-notify
+++ b/ci-notify
@@ -19,7 +19,7 @@ status_rows = []
 loop do
   return_txt = `hub ci-status -v`
   status_rows = return_txt.split("\n").map{ |l| l.split("\t", 3).map{ |s| s.strip} }
-  break if status_rows.all?{|row| test_complete(row)}
+  break if status_rows.select{ |l| /#{test_name_regex}/.match(l[1]) }.all?{|row| test_complete(row)}
   sleep(1)
 end
 

--- a/ci-notify
+++ b/ci-notify
@@ -8,6 +8,8 @@ return_txt = ""
 
 project_name = `basename $(git rev-parse --show-toplevel)`
 
+test_name_regex = ARGV[0] || ".*"
+
 loop do
   return_txt = `hub ci-status -v`
   break unless [PENDING, NO_STATUS].include?($?.exitstatus)
@@ -19,7 +21,7 @@ def notify(status_txt, title, url_args)
 end
 
 status_rows = return_txt.split("\n").map{ |l| l.split("\t", 3).map{ |s| s.strip} }
-rows_by_status = status_rows.group_by{ |l| l[0] }
+rows_by_status = status_rows.select{ |l| /#{test_name_regex}/.match(l[1]) }.group_by{ |l| l[0] }
 
 if rows_by_status[GITHUB_FALURE].nil?
     # success

--- a/ci-notify
+++ b/ci-notify
@@ -10,9 +10,16 @@ project_name = `basename $(git rev-parse --show-toplevel)`
 
 test_name_regex = ARGV[0] || ".*"
 
+def test_complete(parsed_line)
+  [GITHUB_SUCCESS, GITHUB_FALURE].include?(parsed_line[0])
+end
+
+status_rows = []
+
 loop do
   return_txt = `hub ci-status -v`
-  break unless [PENDING, NO_STATUS].include?($?.exitstatus)
+  status_rows = return_txt.split("\n").map{ |l| l.split("\t", 3).map{ |s| s.strip} }
+  break if status_rows.all?{|row| test_complete(row)}
   sleep(1)
 end
 
@@ -20,7 +27,7 @@ def notify(status_txt, title, url_args)
     system("terminal-notifier -message 'Build #{status_txt}' -title '#{title}' #{url_args}")
 end
 
-status_rows = return_txt.split("\n").map{ |l| l.split("\t", 3).map{ |s| s.strip} }
+
 rows_by_status = status_rows.select{ |l| /#{test_name_regex}/.match(l[1]) }.group_by{ |l| l[0] }
 
 if rows_by_status[GITHUB_FALURE].nil?


### PR DESCRIPTION
I really never wanted to have command line args, or regexes, but it seems my hand has been forced here. The gist of it is that you can pass a regex as a positional arg, and ci-notify will report on the status of just those checks matching your regex. Practically, I have this set up by putting a line like the following in my bash profile

```
alias ci-notify="/Users/df/code/ci-notify/ci-notify my-company-ci-.*"
```

Along the way I made some changes so that we wait for all tests to complete, rather than bailing early if a single test has failed.
